### PR TITLE
Fetch block merkle proof in multiple nodes client

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -43,6 +43,11 @@ func TestApiWithEspressoDevNode(t *testing.T) {
 		t.Fatal("failed to fetch headers by range", err)
 	}
 
+	_, err = client.FetchBlockMerkleProof(ctx, 1, blockHeight)
+	if err != nil {
+		t.Fatal("failed to fetch block merkle proof", err)
+	}
+
 }
 
 func runEspresso() func() {

--- a/client/multiple_nodes_client.go
+++ b/client/multiple_nodes_client.go
@@ -70,6 +70,14 @@ func (c *MultipleNodesClient) FetchHeadersByRange(ctx context.Context, from uint
 	return res, nil
 }
 
+func (c *MultipleNodesClient) FetchBlockMerkleProof(ctx context.Context, rootHeight uint64, hotshotHeight uint64) (types.HotShotBlockMerkleProof, error) {
+	var res types.HotShotBlockMerkleProof
+	if err := c.getWithMajority(ctx, &res, "block-state/%d/%d", rootHeight, hotshotHeight); err != nil {
+		return types.HotShotBlockMerkleProof{}, err
+	}
+	return res, nil
+}
+
 func (c *MultipleNodesClient) getWithMajority(ctx context.Context, out any, format string, args ...any) error {
 	body, err := FetchWithMajority(ctx, c.nodes, func(node *Client) (json.RawMessage, error) {
 		return node.getRawMessage(ctx, format, args...)

--- a/client/multiple_nodes_test.go
+++ b/client/multiple_nodes_test.go
@@ -187,6 +187,11 @@ func TestApiWithSingleEspressoDevNode(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to fetch transactions in block", err)
 	}
+
+	_, err = client.FetchBlockMerkleProof(ctx, 1, blockHeight)
+	if err != nil {
+		t.Fatal("failed to fetch block merkle proof", err)
+	}
 }
 
 func getHeaderFromTestFile(path string, t *testing.T) types.HeaderInterface {

--- a/client/query.go
+++ b/client/query.go
@@ -25,6 +25,8 @@ type QueryService interface {
 	FetchTransactionByHash(ctx context.Context, hash *types.TaggedBase64) (types.TransactionQueryData, error)
 	// Get the VidCommon for the given block height.
 	FetchVidCommonByHeight(ctx context.Context, blockHeight uint64) (types.VidCommon, error)
+	// Get the block merkle proof for the given root height and hotshot height.
+	FetchBlockMerkleProof(ctx context.Context, rootHeight uint64, hotshotHeight uint64) (types.HotShotBlockMerkleProof, error)
 }
 
 // Response to `FetchTransactionsInBlock`


### PR DESCRIPTION
- Fix CI
- Add an endpoint to fetch block merkle proof(this should have been done but I missed this endpoint)