### PR TITLE
feat: espresso verification with error messages

### DIFF
--- a/verification/native.go
+++ b/verification/native.go
@@ -57,6 +57,8 @@ func verifyNamespace(namespace uint64, proof []byte, blockComm []byte, nsTable [
 	result := C.verify_namespace_helper(
 		c_namespace, proofPtr, proofLen, blockCommPtr, blockCommLen, nsTablePtr, nsTableLen, txCommPtr, txCommLen, commonDataPtr, commonDataLen)
 	defer C.free_error_string(result.error)
+	// Allocate a new string in go, so we can free the C string
+	// See https://go.dev/wiki/cgo#go-strings-and-c-strings
 	msg := C.GoString(result.error)
 	return bool(result.success), errors.New(msg)
 }
@@ -77,6 +79,7 @@ func verifyMerkleProof(proof []byte, header []byte, blockComm []byte, circuitBlo
 
 	result := C.verify_merkle_proof_helper(proofPtr, proofLen, headerPtr, headerLen, blockCommPtr, blockCommLen, circuitBlockPtr, circuitBlockLen)
 	defer C.free_error_string(result.error)
+	// Allocate a new string in go, so we can free the C string
 	msg := C.GoString(result.error)
 	return bool(result.success), errors.New(msg)
 }

--- a/verification/native.go
+++ b/verification/native.go
@@ -8,13 +8,20 @@ package verification
 #include <stdbool.h>
 #include <stdint.h>
 
-bool verify_merkle_proof_helper(
+typedef struct {
+    bool success;
+    char* error;
+} VerificationResult;
+
+
+extern void free_error_string(char* s);
+extern VerificationResult verify_merkle_proof_helper(
     const uint8_t* proof_ptr, size_t proof_len,
     const uint8_t* header_ptr, size_t header_len,
     const uint8_t* block_comm_ptr, size_t block_comm_len,
     const uint8_t* circuit_block_ptr, size_t circuit_block_len
 );
-bool verify_namespace_helper(
+extern VerificationResult verify_namespace_helper(
     uint64_t namespace,
     const uint8_t* proof_ptr, size_t proof_len,
     const uint8_t* commit_ptr, size_t commit_len,
@@ -24,9 +31,12 @@ bool verify_namespace_helper(
 );
 */
 import "C"
-import "unsafe"
+import (
+	"errors"
+	"unsafe"
+)
 
-func verifyNamespace(namespace uint64, proof []byte, blockComm []byte, nsTable []byte, txComm []byte, commonData []byte) bool {
+func verifyNamespace(namespace uint64, proof []byte, blockComm []byte, nsTable []byte, txComm []byte, commonData []byte) (bool, error) {
 	c_namespace := C.uint64_t(namespace)
 
 	proofPtr := (*C.uint8_t)(unsafe.Pointer(&proof[0]))
@@ -44,13 +54,14 @@ func verifyNamespace(namespace uint64, proof []byte, blockComm []byte, nsTable [
 	commonDataPtr := (*C.uint8_t)(unsafe.Pointer(&commonData[0]))
 	commonDataLen := C.size_t(len(commonData))
 
-	valid_namespace_proof := bool(C.verify_namespace_helper(
-		c_namespace, proofPtr, proofLen, blockCommPtr, blockCommLen, nsTablePtr, nsTableLen, txCommPtr, txCommLen, commonDataPtr, commonDataLen))
-
-	return valid_namespace_proof
+	result := C.verify_namespace_helper(
+		c_namespace, proofPtr, proofLen, blockCommPtr, blockCommLen, nsTablePtr, nsTableLen, txCommPtr, txCommLen, commonDataPtr, commonDataLen)
+	defer C.free_error_string(result.error)
+	msg := C.GoString(result.error)
+	return bool(result.success), errors.New(msg)
 }
 
-func verifyMerkleProof(proof []byte, header []byte, blockComm []byte, circuitBlock []byte) bool {
+func verifyMerkleProof(proof []byte, header []byte, blockComm []byte, circuitBlock []byte) (bool, error) {
 
 	proofPtr := (*C.uint8_t)(unsafe.Pointer(&proof[0]))
 	proofLen := C.size_t(len(proof))
@@ -64,8 +75,8 @@ func verifyMerkleProof(proof []byte, header []byte, blockComm []byte, circuitBlo
 	circuitBlockPtr := (*C.uint8_t)(unsafe.Pointer(&circuitBlock[0]))
 	circuitBlockLen := C.size_t(len(circuitBlock))
 
-	valid_merkle_proof := bool(C.verify_merkle_proof_helper(proofPtr, proofLen, headerPtr, headerLen, blockCommPtr, blockCommLen, circuitBlockPtr, circuitBlockLen))
-
-	return valid_merkle_proof
-
+	result := C.verify_merkle_proof_helper(proofPtr, proofLen, headerPtr, headerLen, blockCommPtr, blockCommLen, circuitBlockPtr, circuitBlockLen)
+	defer C.free_error_string(result.error)
+	msg := C.GoString(result.error)
+	return bool(result.success), errors.New(msg)
 }

--- a/verification/verify.go
+++ b/verification/verify.go
@@ -19,12 +19,12 @@ func VerifyNamespace(
 	ns_table espressoTypes.NsTable,
 	txs []espressoTypes.Bytes,
 	common_data json.RawMessage,
-) bool {
+) (bool, error) {
 	// TODO: this code will likely no longer be used in the STF soon.
 	// G115: integer overflow conversion uint64 -> uint32 (gosec)
 	// #nosec G115
 	var txnComm = hashTxns(uint32(namespace), txs)
-	res := verifyNamespace(
+	return verifyNamespace(
 		namespace,
 		proof,
 		[]byte(block_comm.String()),
@@ -32,7 +32,6 @@ func VerifyNamespace(
 		[]byte(txnComm),
 		common_data,
 	)
-	return res
 }
 
 func VerifyMerkleProof(
@@ -40,7 +39,7 @@ func VerifyMerkleProof(
 	header json.RawMessage,
 	blockComm espressoTypes.TaggedBase64,
 	circuit_comm_bytes espressoTypes.Commitment,
-) bool {
+) (bool, error) {
 	return verifyMerkleProof(proof, header, []byte(blockComm.String()), circuit_comm_bytes[:])
 }
 

--- a/verification/verify_test.go
+++ b/verification/verify_test.go
@@ -42,7 +42,7 @@ func TestVerifyNamespaceWithRealData(t *testing.T) {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
 
-	success := VerifyNamespace(
+	success, err := VerifyNamespace(
 		1918988905,
 		res.Proof,
 		*header.Header.GetPayloadCommitment(),
@@ -51,7 +51,7 @@ func TestVerifyNamespaceWithRealData(t *testing.T) {
 		json.RawMessage(vidCommon.Common),
 	)
 	if !success {
-		t.Fatalf("Failed to verify namespace")
+		t.Fatalf("Failed to verify namespace: %v", err)
 	}
 }
 


### PR DESCRIPTION
Motivation: it's hard to figure out why verifications fail. Currently we compress all the verification results into a single boolean, thereby discarding all information and making debugging unnecessarily hard for us.

With this change our rust library returns an error message alongside the boolean result (value set as before).

The idea is that wherever we call this code from go we can easily log the error. The existing go code function wrappers should take care of free-ing the memory allocated in rust but I don't know how to actually test if this is working.

A bit of verification code has been re-organized to be able to create a specific error message.

Note: this is a small API breakage: callers of `VerifyNamespace` and `VerifyMerkleProof` will now receive `(bool, error)` instead of just a `bool`, and should log the error if the boolean is false.

