### PR TITLE
Support downloading library from a given url

### DIFF
--- a/.github/workflows/build-dynamic.yml
+++ b/.github/workflows/build-dynamic.yml
@@ -63,8 +63,7 @@ jobs:
             cp ./verification/rust/target/${{ matrix.target }}/release/libespresso_crypto_helper.so target/lib/libespresso_crypto_helper-${{ matrix.target }}.so
           fi
 
-      - name: Upload Artifact (Push Only)
-        if: github.event_name == 'push'
+      - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: libespresso_crypto_helper-${{ matrix.target }}.${{ contains(matrix.target, 'apple-darwin') && 'dylib' || 'so' }}

--- a/download/main.go
+++ b/download/main.go
@@ -18,16 +18,18 @@ const baseURL = "https://github.com/EspressoSystems/espresso-network-go/releases
 
 func main() {
 	var version string
+	var url string
 
 	var rootCmd = &cobra.Command{Use: "app"}
 	var downloadCmd = &cobra.Command{
 		Use:   "download",
 		Short: "Download the static library",
 		Run: func(cmd *cobra.Command, args []string) {
-			download(version)
+			download(version, url)
 		},
 	}
 	downloadCmd.Flags().StringVarP(&version, "version", "v", "latest", "Specify the version to download")
+	downloadCmd.Flags().StringVarP(&url, "url", "u", "", "Specify the url to download. If this is set, the version flag will be ignored")
 
 	var cleanCmd = &cobra.Command{
 		Use:   "clean",
@@ -45,13 +47,13 @@ func main() {
 	}
 }
 
-func download(version string) {
+func download(version string, specifiedUrl string) {
 	fileName := getFileName()
 	fileDir := getFileDir()
 	libFilePath := filepath.Join(fileDir, fileName)
 
 	if _, err := os.Stat(libFilePath); err == nil {
-		fmt.Println("File already exists.")
+		fmt.Println("File already exists. Run clean to remove it first.")
 		return
 	}
 
@@ -60,7 +62,13 @@ func download(version string) {
 		os.Exit(1)
 	}
 
-	url := fmt.Sprintf("%s/download/%s/%s", baseURL, version, fileName)
+	var url string
+	if specifiedUrl != "" {
+		fmt.Printf("Using specified url to download the library: %s\n", specifiedUrl)
+		url = specifiedUrl
+	} else {
+		url = fmt.Sprintf("%s/download/%s/%s", baseURL, version, fileName)
+	}
 
 	resp, err := http.Get(url)
 	if err != nil {

--- a/verification/native.go
+++ b/verification/native.go
@@ -2,7 +2,7 @@ package verification
 
 /*
 #cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/../target/lib/ -lespresso_crypto_helper-x86_64-apple-darwin -lm
-#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../target/lib/ -lespresso_crypto_helper-aarch64-apple-darwin -lm -framework Security
+#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../target/lib/ -lespresso_crypto_helper-aarch64-apple-darwin -lm
 #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../target/lib/ -lespresso_crypto_helper-x86_64-unknown-linux-gnu -lm
 #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../target/lib/ -lespresso_crypto_helper-aarch64-unknown-linux-gnu -lm
 #include <stdbool.h>
@@ -57,10 +57,13 @@ func verifyNamespace(namespace uint64, proof []byte, blockComm []byte, nsTable [
 	result := C.verify_namespace_helper(
 		c_namespace, proofPtr, proofLen, blockCommPtr, blockCommLen, nsTablePtr, nsTableLen, txCommPtr, txCommLen, commonDataPtr, commonDataLen)
 	defer C.free_error_string(result.error)
+	if bool(result.success) {
+		return true, nil
+	}
 	// Allocate a new string in go, so we can free the C string
 	// See https://go.dev/wiki/cgo#go-strings-and-c-strings
 	msg := C.GoString(result.error)
-	return bool(result.success), errors.New(msg)
+	return false, errors.New(msg)
 }
 
 func verifyMerkleProof(proof []byte, header []byte, blockComm []byte, circuitBlock []byte) (bool, error) {
@@ -79,7 +82,11 @@ func verifyMerkleProof(proof []byte, header []byte, blockComm []byte, circuitBlo
 
 	result := C.verify_merkle_proof_helper(proofPtr, proofLen, headerPtr, headerLen, blockCommPtr, blockCommLen, circuitBlockPtr, circuitBlockLen)
 	defer C.free_error_string(result.error)
+	if bool(result.success) {
+		return true, nil
+	}
 	// Allocate a new string in go, so we can free the C string
+	// See https://go.dev/wiki/cgo#go-strings-and-c-strings
 	msg := C.GoString(result.error)
-	return bool(result.success), errors.New(msg)
+	return false, errors.New(msg)
 }

--- a/verification/rust/src/lib.rs
+++ b/verification/rust/src/lib.rs
@@ -38,7 +38,10 @@ pub struct VerificationResult {
 impl VerificationResult {
     fn err(msg: &str) -> VerificationResult {
         let ptr = CString::new(msg).unwrap().into_raw();
-        VerificationResult{ success: false, error: ptr }
+        VerificationResult {
+            success: false,
+            error: ptr,
+        }
     }
 
     fn success() -> VerificationResult {
@@ -62,8 +65,6 @@ pub extern "C" fn free_error_string(s: *mut c_char) {
         }
     }
 }
-
-
 
 // Helper function to verify a block merkle proof.
 // proof_bytes: Byte representation of a block merkle proof.
@@ -168,7 +169,10 @@ pub extern "C" fn verify_namespace_helper(
     let namespace: u32 = handle_result!(namespace.try_into());
 
     if ns != namespace.into() {
-        return VerificationResult::err(&format!("namespace mismatch: proven {} != expected {}", ns, namespace));
+        return VerificationResult::err(&format!(
+            "namespace mismatch: proven {} != expected {}",
+            ns, namespace
+        ));
     };
 
     let txns_comm = hash_txns(namespace, &txns);


### PR DESCRIPTION
- add a flag to support downloading artifact from a given url
- always upload artifacts

This is helpful when debugging. Artifacts can be found in the CI:
https://github.com/EspressoSystems/espresso-network-go/actions/runs/14831393954?pr=87