### PR TITLE
Add checksum file to artifacts

### DIFF
--- a/.github/workflows/build-dynamic.yml
+++ b/.github/workflows/build-dynamic.yml
@@ -58,16 +58,26 @@ jobs:
           cargo build --release --locked --target ${{ matrix.target }} --manifest-path ./verification/rust/Cargo.toml && \
           if [ "$(uname -s)" == "Darwin" ]; then
             cp ./verification/rust/target/${{ matrix.target }}/release/libespresso_crypto_helper.dylib target/lib/libespresso_crypto_helper-${{ matrix.target }}.dylib
+            shasum -a 256 target/lib/libespresso_crypto_helper-${{ matrix.target }}.dylib | awk '{print $1}' > target/lib/libespresso_crypto_helper-${{ matrix.target }}.dylib.sha256
           fi
           if [ "$(uname -s)" != "Darwin" ]; then
             cp ./verification/rust/target/${{ matrix.target }}/release/libespresso_crypto_helper.so target/lib/libespresso_crypto_helper-${{ matrix.target }}.so
+            shasum -a 256 target/lib/libespresso_crypto_helper-${{ matrix.target }}.so | awk '{print $1}' > target/lib/libespresso_crypto_helper-${{ matrix.target }}.so.sha256
           fi
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: libespresso_crypto_helper-${{ matrix.target }}.${{ contains(matrix.target, 'apple-darwin') && 'dylib' || 'so' }}
-          path: target/lib/libespresso_crypto_helper-${{ matrix.target }}.${{ contains(matrix.target, 'apple-darwin') && 'dylib' || 'so' }}
+          path: |
+            target/lib/libespresso_crypto_helper-${{ matrix.target }}.${{ contains(matrix.target, 'apple-darwin') && 'dylib' || 'so' }}
+
+      - name: Upload sha256 files
+        uses: actions/upload-artifact@v4
+        with:
+          name: libespresso_crypto_helper-${{ matrix.target }}.${{ contains(matrix.target, 'apple-darwin') && 'dylib' || 'so' }}.sha256
+          path: |
+            target/lib/libespresso_crypto_helper-${{ matrix.target }}.${{ contains(matrix.target, 'apple-darwin') && 'dylib' || 'so' }}.sha256
 
   release:
     name: Upload Release Artifacts
@@ -90,3 +100,5 @@ jobs:
           files: |
             target/lib/*/*.dylib
             target/lib/*/*.so
+            target/lib/*/*.dylib.sha256
+            target/lib/*/*.so.sha256

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,5 +53,5 @@ jobs:
         run: |
           if [ "$(uname -s)" != "Darwin" ]; then
             export LD_LIBRARY_PATH="$PWD/target/lib:$LD_LIBRARY_PATH"
-          fi         
+          fi
           just test

--- a/download/main.go
+++ b/download/main.go
@@ -168,7 +168,7 @@ func download(version string, specifiedUrl string, destination string) {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Static library downloaded to: %s\n", destination)
+	fmt.Printf("Verification library downloaded to: %s\n", destination)
 }
 
 func clean() {

--- a/download/main.go
+++ b/download/main.go
@@ -67,13 +67,13 @@ func createSymlink(path string, checkSum string) {
 	fileDir := getFileDir()
 	linkPath := filepath.Join(fileDir, linkName)
 
-	if !filepath.IsAbs(linkPath) {
-		absPath, err := filepath.Abs(linkPath)
+	if !filepath.IsAbs(path) {
+		absPath, err := filepath.Abs(path)
 		if err != nil {
 			fmt.Printf("Failed to get absolute path: %s\n", err)
 			os.Exit(1)
 		}
-		linkPath = absPath
+		path = absPath
 	}
 
 	if _, err := os.Stat(linkPath); err == nil {

--- a/justfile
+++ b/justfile
@@ -41,6 +41,8 @@ os_name := `uname -s`
 build-verification:
 	@if [ "{{os_name}}" != "Darwin" ]; then \
 		export LD_LIBRARY_PATH="$$(pwd)/target/lib:$$LD_LIBRARY_PATH"; \
+	else \
+		export DYLD_LIBRARY_PATH="$$(pwd)/target/lib:$$DYLD_LIBRARY_PATH"; \
 	fi
 	mkdir -p {{target_lib}}
 	cargo build --release --manifest-path {{verification_dir}}/Cargo.toml

--- a/verification/rust/.cargo/config.toml
+++ b/verification/rust/.cargo/config.toml
@@ -1,0 +1,11 @@
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-C",
+    "link-arg=-Wl,-install_name,@rpath/libespresso_crypto_helper-aarch64-apple-darwin.dylib",
+]
+
+[target.x86_64-apple-darwin]
+rustflags = [
+    "-C",
+    "link-arg=-Wl,-install_name,@rpath/libespresso_crypto_helper-x86_64-apple-darwin.dylib",
+]


### PR DESCRIPTION
### This PR:
- Generates files containing checksums of the artifacts to ensure the node is running the correct and complete verification binary.
- Adds a symlink command, allowing users to download the libraries to an arbitrary folder and link the library files manually.
- Fixes a bug where macOS builds Rust libraries with a built-in install name, preventing the binary from being used in other directories.


### How to test this PR:
- Under the root directory, run the command:
```
go run ./download/main.go download -v v0.0.36 -d ./
```
to see if the file is downloaded successfully
- Run `just build-verification` and `go test ./verification` to see if everything works
- Move the new created library file (./target/lib/*.dylib or ./target/lib/*.so) to the root directory. Run
```
go run ./download/main.go link -f ./{your file} -c {arbitary string}
```
to see if the command error when checksum unmatches.
- Run this command:
```
go run ./download/main.go link -f ./{your file} -c {checksum}
```
and check if the symlink is created under ./target/lib
- Run `go test -count=1 ./verification` to see if it works with the symlink


> ➜  espresso-sequencer-go git:(jh/ux) ✗ go run ./download/main.go link -f ./libespresso_crypto_helper-aarch64-apple-darwin.dylib -c 21f3efbba8045aa4c12103d7e8bf78c6fd49fd82e0626217fb03efedaa382efb
Checksum mismatch: 6a7f5dd99c6615a6f675597627cde6be18d983113465dd35e96067a1fe696034 != 21f3efbba8045aa4c12103d7e8bf78c6fd49fd82e0626217fb03efedaa382efb
exit status 1
➜  espresso-sequencer-go git:(jh/ux) ✗ go run ./download/main.go link -f ./libespresso_crypto_helper-aarch64-apple-darwin.dylib -c 6a7f5dd99c6615a6f675597627cde6be18d983113465dd35e96067a1fe696034
Created symlink: /Users/jeremyhe/work/espresso-sequencer-go/target/lib/libespresso_crypto_helper-aarch64-apple-darwin.dylib
➜  espresso-sequencer-go git:(jh/ux) ✗ go test ./verification
ok  	github.com/EspressoSystems/espresso-network-go/verification	(cached)
➜  espresso-sequencer-go git:(jh/ux) ✗ go test -count=1 ./verification
ok  	github.com/EspressoSystems/espresso-network-go/verification	0.411s