### PR TITLE
Require more than one url for multi node client

### DIFF
--- a/client/multiple_nodes_client.go
+++ b/client/multiple_nodes_client.go
@@ -18,16 +18,21 @@ var _ QueryService = (*MultipleNodesClient)(nil)
 var _ SubmitAPI = (*MultipleNodesClient)(nil)
 var _ EspressoClient = (*MultipleNodesClient)(nil)
 
+var IncorrectUrlAmountErr = errors.New("The MultipleNodesClient must be constructed with a")
+
 type MultipleNodesClient struct {
 	nodes []*Client
 }
 
-func NewMultipleNodesClient(urls []string) *MultipleNodesClient {
+func NewMultipleNodesClient(urls []string) (*MultipleNodesClient, error) {
 	nodes := make([]*Client, len(urls))
+	if len(urls) <= 1 {
+		return nil, IncorrectUrlAmountErr
+	}
 	for i, url := range urls {
 		nodes[i] = NewClient(url)
 	}
-	return &MultipleNodesClient{nodes: nodes}
+	return &MultipleNodesClient{nodes: nodes}, nil
 }
 
 func (c *MultipleNodesClient) FetchLatestBlockHeight(ctx context.Context) (uint64, error) {

--- a/client/multiple_nodes_client.go
+++ b/client/multiple_nodes_client.go
@@ -18,7 +18,7 @@ var _ QueryService = (*MultipleNodesClient)(nil)
 var _ SubmitAPI = (*MultipleNodesClient)(nil)
 var _ EspressoClient = (*MultipleNodesClient)(nil)
 
-var IncorrectUrlAmountErr = errors.New("The MultipleNodesClient must be constructed with a")
+var IncorrectUrlAmountErr = errors.New("The MultipleNodesClient must be constructed with more than one node url")
 
 type MultipleNodesClient struct {
 	nodes []*Client

--- a/client/multiple_nodes_test.go
+++ b/client/multiple_nodes_test.go
@@ -160,8 +160,16 @@ func TestApiWithSingleEspressoDevNode(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to start espresso dev node", err)
 	}
+  // Test constructing the client with a single url to ensure that it requires more than one.
+	_, err = NewMultipleNodesClient([]string{"http://localhost:21000"})
+  if err == nil{
+    t.Fatal("Constructing the client with 1 url should result in an error")
+  }
 
-	client := NewMultipleNodesClient([]string{"http://localhost:21000"})
+	client, err := NewMultipleNodesClient([]string{"http://localhost:21000", "http://localhost:21000"})
+  if err == nil{
+    t.Fatal("Constructing the client with 1 url should result in an error")
+  }
 
 	_, err = client.FetchLatestBlockHeight(ctx)
 	if err != nil {

--- a/client/multiple_nodes_test.go
+++ b/client/multiple_nodes_test.go
@@ -160,16 +160,16 @@ func TestApiWithSingleEspressoDevNode(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to start espresso dev node", err)
 	}
-  // Test constructing the client with a single url to ensure that it requires more than one.
+	// Test constructing the client with a single url to ensure that it requires more than one.
 	_, err = NewMultipleNodesClient([]string{"http://localhost:21000"})
-  if err == nil{
-    t.Fatal("Constructing the client with 1 url should result in an error")
-  }
+	if err == nil {
+		t.Fatal("Constructing the client with 1 url should result in an error")
+	}
 
 	client, err := NewMultipleNodesClient([]string{"http://localhost:21000", "http://localhost:21000"})
-  if err == nil{
-    t.Fatal("Constructing the client with 1 url should result in an error")
-  }
+	if err != nil {
+		t.Fatal("Constructing the client with more than 1 url should succeed")
+	}
 
 	_, err = client.FetchLatestBlockHeight(ctx)
 	if err != nil {


### PR DESCRIPTION
Closes [Asana ticket](https://app.asana.com/1/1208976916964769/project/1209976130071762/task/1210226042034686?focus=true)

### This PR:
Requires that the multiple nodes client is constructed with more than one url.
Update the tests to test the new feature of the multiple nodes client.

### Key places to review:
`client/multiple_nodes_client.go`
`client/multiple_nodes_test.go`
### How to test this PR: 
`just test`